### PR TITLE
check app.dock exists, so electron is happy on non-mac

### DIFF
--- a/main.js
+++ b/main.js
@@ -63,4 +63,4 @@ function createWindow () {
   mainWindow.loadURL(`file://${path.join(__dirname, 'index.html')}`)
 }
 
-app.dock.hide()
+if ('dock' in app) app.dock.hide()


### PR DESCRIPTION
:+1: Your repo tags were very helpful. Looking forward to using this as a ref for a side project. 

This is a silly PR, just so `npm start` works on non-mac (linux).
